### PR TITLE
Return the number of mbuf's that have been consumed

### DIFF
--- a/drivers/wrs-avp/15.12/wrs-avp-pmd-1.2.6/wrs/lib/libwrs_pmd_avp/avp_ethdev.c
+++ b/drivers/wrs-avp/15.12/wrs-avp-pmd-1.2.6/wrs/lib/libwrs_pmd_avp/avp_ethdev.c
@@ -1793,7 +1793,7 @@ avp_xmit_scattered_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_p
         WRS_AVP_STATS_ADD(avp, tx_errors, (orig_nb_pkts - n));
     }
 
-    return n;
+    return nb_pkts;
 }
 
 
@@ -1909,7 +1909,7 @@ avp_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
     /* send the packets */
     n = avp_fifo_put(tx_q, (void**)&avp_bufs[0], count);
 
-    return n;
+    return count;
 }
 
 static void

--- a/drivers/wrs-avp/16.10/wrs-avp-pmd-1.2.8/wrs/lib/libwrs_pmd_avp/avp_ethdev.c
+++ b/drivers/wrs-avp/16.10/wrs-avp-pmd-1.2.8/wrs/lib/libwrs_pmd_avp/avp_ethdev.c
@@ -1856,7 +1856,7 @@ avp_xmit_scattered_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_p
         WRS_AVP_STATS_ADD(avp, tx_errors, (orig_nb_pkts - n));
     }
 
-    return n;
+    return nb_pkts;
 }
 
 
@@ -1972,7 +1972,7 @@ avp_xmit_pkts(void *tx_queue, struct rte_mbuf **tx_pkts, uint16_t nb_pkts)
     /* send the packets */
     n = avp_fifo_put(tx_q, (void**)&avp_bufs[0], count);
 
-    return n;
+    return count;
 }
 
 static void


### PR DESCRIPTION
Even if transmit fails for some of these, they have already been freed
and we need to tell the next layer that we have done so.